### PR TITLE
Fix approveAddress in getQuote response

### DIFF
--- a/app/controllers/quote.controller.js
+++ b/app/controllers/quote.controller.js
@@ -202,7 +202,7 @@ exports.create = async (req, res) => {
 			message: err.message
 		});
 		return;
-	}	
+	}
 
 	let priceWei;
 	try {
@@ -222,6 +222,7 @@ exports.create = async (req, res) => {
 	const quoteId = crypto.randomBytes(16).toString("hex");
 
 	// save data in database
+	const wallet = new ethers.Wallet(process.env.PRIVATE_KEY);
 	const quote = new Quote({
 		quoteId: quoteId,
 		status: Quote.QUOTE_STATUS_WAITING,
@@ -230,7 +231,7 @@ exports.create = async (req, res) => {
 		tokenAddress: tokenAddress,
 		userAddress: userAddress,
 		tokenAmount: tokenAmount.toString(),
-		approveAddress: "0x0000000000000000000000000000000000000000", // TODO: replace with real address
+		approveAddress: wallet.address,
 		files: file_lengths
 
 	});


### PR DESCRIPTION
Towards #4 

Changes:

- Fix `approveAddress` in `getQuote` response. Return actual address based on `process.env.PRIVATE_KEY` instead of `0x0` address.