### PR TITLE
add Goerli test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
         # Test env var
         TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
         ENABLE_EXPENSIVE_TESTS: false
-        CHAIN_ID: ${{ matrix.payment.chain-id }}
-        TOKEN_ADDRESS: ${{ matrix.payment.token-address }}
+        CHAIN_ID: ${{ matrix.payment.chainId }}
+        TOKEN_ADDRESS: ${{ matrix.payment.tokenAddress }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
+        payment: [
+          {
+            chainId: 80001,
+            tokenAddress: "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"
+          },
+          {
+            chainId: 5,
+            tokenAddress: "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
+          }
+        ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -52,3 +62,5 @@ jobs:
         # Test env var
         TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
         ENABLE_EXPENSIVE_TESTS: false
+        CHAIN_ID: ${{ matrix.payment.chain-id }}
+        TOKEN_ADDRESS: ${{ matrix.payment.token-address }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         npm start 2>&1 &
         sleep 2
-        npm test -- -grep "upload, with large file"
+        npm test -- -grep "Goerli"
       env:
         # Server env vars
         ACCEPTED_PAYMENTS: ethereum,matic,boba,boba-eth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,11 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        payment: [
-          {
-            chainId: 80001,
+        payment:
+          - chainId: 80001
             tokenAddress: "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"
-          },
-          {
-            chainId: 5,
+          - chainId: 5
             tokenAddress: "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
-          }
-        ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         IPFS_GATEWAY: https://cloudflare-ipfs.com/ipfs/
         ARWEAVE_GATEWAY: https://arweave.net/
         MAX_UPLOAD_SIZE: 1099511627776
+        PRICE_BUFFER: 20
         # Test env var
         TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
         ENABLE_EXPENSIVE_TESTS: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         payment:
           - chainId: 80001
             tokenAddress: "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"
           - chainId: 5
             tokenAddress: "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v3

--- a/app/controllers/config.js
+++ b/app/controllers/config.js
@@ -176,6 +176,12 @@ const checkConfig = () => {
 		return false;
 	}
 
+	const priceBuffer = process.env.PRICE_BUFFER;
+	if(priceBuffer != null && isNaN(priceBuffer)) {
+		console.log("PRICE_BUFFER environment variable should be a number");
+		return false;
+	}
+
 	return true;
 };
 

--- a/app/controllers/quote.controller.js
+++ b/app/controllers/quote.controller.js
@@ -186,7 +186,9 @@ exports.create = async (req, res) => {
 		errorResponse(req, res, err, 500, "Unable to get price from payment processor.");
 		return;
 	}
-	const tokenAmount = priceWei.add(priceWei.div(10)); // add 10% buffer since prices fluctuate
+
+	// add buffer since price fluctuates
+	const tokenAmount = priceWei.add(priceWei.div(process.env.PRICE_BUFFER ?? 10));
 
 	// Create provider
 	let provider;

--- a/test/test.helpers.js
+++ b/test/test.helpers.js
@@ -7,8 +7,8 @@ exports.getQuote = async (wallet, size = 119762) => {
         userAddress: wallet.address,
         files: [{length: size}, {length: 13}],
         payment: {
-            chainId: 80001,
-            tokenAddress: "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889", // WMATIC on Mumbai
+            chainId: process.env.CHAIN_ID,
+            tokenAddress: process.env.TOKEN_ADDRESS,
         },
     });
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,8 @@ const Quote = require("../app/models/quote.model.js");
 const { getToken } = require("../app/controllers/tokens.js");
 
 describe("DBS Arweave Upload", function () {
+    console.log(process.env.CHAIN_ID);
+    console.log(process.env.TOKEN_ADDRESS);
     const providerUri = getToken(parseInt(process.env.CHAIN_ID), process.env.TOKEN_ADDRESS).providerUrl;
     const provider = ethers.getDefaultProvider(providerUri);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);

--- a/test/test.js
+++ b/test/test.js
@@ -245,7 +245,13 @@ describe("DBS Arweave Upload", function () {
                     "approveAddress"
                 );
 
-                await (await goerliToken.approve(quote.approveAddress, ethers.constants.MaxInt256)).wait();
+                try {
+                    await (await goerliToken.approve(quote.approveAddress, ethers.constants.MaxInt256)).wait();
+                }
+                catch(err) {
+                    console.log("goerliToken error");
+                    console.log(err);
+                }
 
                 let nonce = Math.floor(new Date().getTime()) / 1000;
                 let message = ethers.utils.sha256(ethers.utils.toUtf8Bytes(quote.quoteId + nonce.toString()));

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,11 @@ const axios = require("axios");
 const { expect } = require("chai");
 const { getQuote, waitForUpload } = require("./test.helpers.js");
 const Quote = require("../app/models/quote.model.js");
+const { getToken } = require("../app/controllers/tokens.js");
 
 describe("DBS Arweave Upload", function () {
-    const provider = ethers.getDefaultProvider(process.env.CHAIN_ID);
+    const providerUri = getToken(process.env.CHAIN_ID, process.env.TOKEN_ADDRESS).providerUrl;
+    const provider = ethers.getDefaultProvider(providerUri);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);
     console.log(`user wallet address: ${userWallet.address}`);
 

--- a/test/test.js
+++ b/test/test.js
@@ -129,7 +129,7 @@ describe("DBS Arweave Upload", function () {
             });
 
             it("upload, with approval, should respond 403 when nonce is old", async function() {
-                const timeoutSeconds = 100;
+                const timeoutSeconds = 200;
                 this.timeout(timeoutSeconds * 1000);
 
                 const getQuoteResponse = await getQuote(userWallet).catch((err) => err.response);
@@ -166,7 +166,7 @@ describe("DBS Arweave Upload", function () {
             });
 
             it("upload, with approval, should fail when invalid IPFS URI", async function() {
-                const timeoutSeconds = 200;
+                const timeoutSeconds = 300;
                 this.timeout(timeoutSeconds * 1000);
 
                 const quoteResponse = await getQuote(userWallet).catch((err) => err.response);

--- a/test/test.js
+++ b/test/test.js
@@ -221,6 +221,56 @@ describe("DBS Arweave Upload", function () {
                 );
             });
 
+
+            it("upload, via Goerli test network, after successful upload, should return a list of transaction IDs", async function() {
+                const quoteResponse = await axios.post(`http://localhost:8081/getQuote`, {
+                    type: "arweave",
+                    userAddress: userWallet.address,
+                    files: [{length: size}, {length: 13}],
+                    payment: {
+                        chainId: 5,
+                        tokenAddress: "0x0000000000000000000000000000000000000000",
+                    },
+                });
+
+                const quote = getQuoteResponse.data;
+                expect(getQuoteResponse.status).equals(200);
+                expect(quote).contains.all.keys(
+                    "quoteId",
+                    "chainId",
+                    "tokenAddress",
+                    "tokenAmount",
+                    "approveAddress"
+                );
+
+                await (await token.approve(quote.approveAddress, ethers.constants.MaxInt256)).wait();
+
+                let nonce = Math.floor(new Date().getTime()) / 1000;
+                let message = ethers.utils.sha256(ethers.utils.toUtf8Bytes(quote.quoteId + nonce.toString()));
+                let signature = await userWallet.signMessage(message);
+                const uploadResponse = await axios.post(`http://localhost:8081/upload`, {
+                    quoteId: quote.quoteId,
+                    files: ["ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", "ipfs://QmZ4tDuvesekSs4qM5ZBKpXiZGun7S2CYtEZRB3DYXkjGx"],
+                    nonce: nonce,
+                    signature: signature,
+                }).catch((err) => err.response);
+                expect(uploadResponse.status).equals(200);
+                expect(uploadResponse.data).equals('');
+
+                const status = await waitForUpload(timeoutSeconds, quote.quoteId);
+                expect(status).equals(Quote.QUOTE_STATUS_UPLOAD_END);
+
+                nonce = Math.floor(new Date().getTime()) / 1000;
+                message = ethers.utils.sha256(ethers.utils.toUtf8Bytes(quote.quoteId + nonce.toString()));
+                signature = await userWallet.signMessage(message);
+                const getLinkResponse = await axios.get(`http://localhost:8081/getLink?quoteId=${quote.quoteId}&nonce=${nonce}&signature=${signature}`);
+                expect(getLinkResponse.status).to.equal(200);
+                expect(getLinkResponse.data[0]).contains.all.keys(
+                    "type",
+                    "transactionHash"
+                );
+            });
+
             it("upload, with large file, should successfully upload file to arweave", async function() {
                 if (process.env.ENABLE_EXPENSIVE_TESTS == "true") {
                     const timeoutSeconds = 3600;

--- a/test/test.js
+++ b/test/test.js
@@ -223,6 +223,8 @@ describe("DBS Arweave Upload", function () {
 
 
             it("upload, via Goerli test network, after successful upload, should return a list of transaction IDs", async function() {
+                const goerliToken = new ethers.Contract("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6", abi, userWallet);
+
                 const quoteResponse = await axios.post(`http://localhost:8081/getQuote`, {
                     type: "arweave",
                     userAddress: userWallet.address,
@@ -243,7 +245,7 @@ describe("DBS Arweave Upload", function () {
                     "approveAddress"
                 );
 
-                await (await token.approve(quote.approveAddress, ethers.constants.MaxInt256)).wait();
+                await (await goerliToken.approve(quote.approveAddress, ethers.constants.MaxInt256)).wait();
 
                 let nonce = Math.floor(new Date().getTime()) / 1000;
                 let message = ethers.utils.sha256(ethers.utils.toUtf8Bytes(quote.quoteId + nonce.toString()));

--- a/test/test.js
+++ b/test/test.js
@@ -233,8 +233,8 @@ describe("DBS Arweave Upload", function () {
                     },
                 });
 
-                const quote = getQuoteResponse.data;
-                expect(getQuoteResponse.status).equals(200);
+                const quote = quoteResponse.data;
+                expect(quoteResponse.status).equals(200);
                 expect(quote).contains.all.keys(
                     "quoteId",
                     "chainId",

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,14 @@ const { getQuote, waitForUpload } = require("./test.helpers.js");
 const Quote = require("../app/models/quote.model.js");
 const { getToken } = require("../app/controllers/tokens.js");
 
+describe("test", function () {
+    it("it", function () {
+        console.log(process.env.CHAIN_ID);
+        console.log(process.env.TOKEN_ADDRESS);
+    });
+});
+
+
 describe("DBS Arweave Upload", function () {
     console.log(process.env.CHAIN_ID);
     console.log(process.env.TOKEN_ADDRESS);

--- a/test/test.js
+++ b/test/test.js
@@ -226,7 +226,7 @@ describe("DBS Arweave Upload", function () {
                 const quoteResponse = await axios.post(`http://localhost:8081/getQuote`, {
                     type: "arweave",
                     userAddress: userWallet.address,
-                    files: [{length: size}, {length: 13}],
+                    files: [{length: 119762}, {length: 13}],
                     payment: {
                         chainId: 5,
                         tokenAddress: "0x0000000000000000000000000000000000000000",

--- a/test/test.js
+++ b/test/test.js
@@ -14,8 +14,9 @@ describe("test", function () {
 
 
 describe("DBS Arweave Upload", function () {
-    console.log(process.env.CHAIN_ID);
-    console.log(process.env.TOKEN_ADDRESS);
+    //console.log(process.env.CHAIN_ID);
+    //console.log(process.env.TOKEN_ADDRESS);
+    expect(process.env.CHAIN_ID).equals(80001);
     const providerUri = getToken(parseInt(process.env.CHAIN_ID), process.env.TOKEN_ADDRESS).providerUrl;
     const provider = ethers.getDefaultProvider(providerUri);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);

--- a/test/test.js
+++ b/test/test.js
@@ -85,7 +85,7 @@ describe("DBS Arweave Upload", function () {
         });
 
         describe("with approval", function () {
-            const timeoutSeconds = 100;
+            const timeoutSeconds = 200;
             this.timeout(timeoutSeconds * 1000);
 
             afterEach("revoke approval", async function () {
@@ -122,9 +122,6 @@ describe("DBS Arweave Upload", function () {
             });
 
             it("upload, with approval, should respond 403 when nonce is old", async function() {
-                const timeoutSeconds = 200;
-                this.timeout(timeoutSeconds * 1000);
-
                 const getQuoteResponse = await getQuote(userWallet).catch((err) => err.response);
                 const quote = getQuoteResponse.data;
                 const token = new ethers.Contract(quote.tokenAddress, abi, userWallet);

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const { getQuote, waitForUpload } = require("./test.helpers.js");
 const Quote = require("../app/models/quote.model.js");
 
 describe("DBS Arweave Upload", function () {
-    const provider = ethers.getDefaultProvider("https://rpc-mumbai.maticvigil.com/");
+    const provider = ethers.getDefaultProvider(process.env.CHAIN_ID);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);
     console.log(`user wallet address: ${userWallet.address}`);
 
@@ -87,9 +87,7 @@ describe("DBS Arweave Upload", function () {
 
             afterEach("revoke approval", async function () {
                 const serverWallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
-                // TODO: Get address from ENV var
-                // WMATIC on Mumbai (Polygon Testnet): https://mumbai.polygonscan.com/token/0x9c3c9283d3e44854697cd22d3faa240cfb032889
-                const token = new ethers.Contract("0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889", abi, userWallet);
+                const token = new ethers.Contract(process.env.TOKEN_ADDRESS, abi, userWallet);
                 await (await token.approve(serverWallet.address, ethers.BigNumber.from(0))).wait();
             });
 

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ const Quote = require("../app/models/quote.model.js");
 const { getToken } = require("../app/controllers/tokens.js");
 
 describe("DBS Arweave Upload", function () {
-    const providerUri = getToken(process.env.CHAIN_ID, process.env.TOKEN_ADDRESS).providerUrl;
+    const providerUri = getToken(parseInt(process.env.CHAIN_ID), process.env.TOKEN_ADDRESS).providerUrl;
     const provider = ethers.getDefaultProvider(providerUri);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);
     console.log(`user wallet address: ${userWallet.address}`);

--- a/test/test.js
+++ b/test/test.js
@@ -5,13 +5,6 @@ const { getQuote, waitForUpload } = require("./test.helpers.js");
 const Quote = require("../app/models/quote.model.js");
 const { getToken } = require("../app/controllers/tokens.js");
 
-describe("test", function () {
-    it("it", function () {
-        console.log(process.env.CHAIN_ID);
-        console.log(process.env.TOKEN_ADDRESS);
-    });
-});
-
 
 describe("DBS Arweave Upload", function () {
     const providerUri = getToken(parseInt(process.env.CHAIN_ID), process.env.TOKEN_ADDRESS).providerUrl;

--- a/test/test.js
+++ b/test/test.js
@@ -14,9 +14,6 @@ describe("test", function () {
 
 
 describe("DBS Arweave Upload", function () {
-    //console.log(process.env.CHAIN_ID);
-    //console.log(process.env.TOKEN_ADDRESS);
-    expect(process.env.CHAIN_ID).equals(80001);
     const providerUri = getToken(parseInt(process.env.CHAIN_ID), process.env.TOKEN_ADDRESS).providerUrl;
     const provider = ethers.getDefaultProvider(providerUri);
     const userWallet = new ethers.Wallet(process.env.TEST_PRIVATE_KEY, provider);


### PR DESCRIPTION
Fixes #69.

Changes:

- Add envvars: CHAIN_ID, TOKEN_ADDRESS, PRICE_BUFFER
- Matrix CI tests on Goerli and Mumbai, run in parallel
- Increase timeouts on tests with successful payments (cause Goerli is slow)